### PR TITLE
chore: release v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mono"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "clap",
  "cliclack",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "mono-changeset"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "globset",
  "mono-project",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "mono-repository"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "git2",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-mono-changeset = { version = "0.0.2", path = "crates/mono-changeset" }
+mono-changeset = { version = "0.0.3", path = "crates/mono-changeset" }
 mono-project = { version = "0.0.2", path = "crates/mono-project" }
-mono-repository = { version = "0.0.2", path = "crates/mono-repository" }
+mono-repository = { version = "0.0.3", path = "crates/mono-repository" }
 
 clap = { version = "4.5", features = ["derive"] }
 cliclack = "0.3"

--- a/crates/mono-changeset/Cargo.toml
+++ b/crates/mono-changeset/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-changeset"
-version = "0.0.2"
+version = "0.0.3"
 description = "Mono repository changeset utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono-repository/Cargo.toml
+++ b/crates/mono-repository/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-repository"
-version = "0.0.2"
+version = "0.0.3"
 description = "Mono repository git utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono/Cargo.toml
+++ b/crates/mono/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono"
-version = "0.0.2"
+version = "0.0.3"
 description = "Mono repository automation toolkit"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This release adds the ability to define additional scopes in a `.mono.toml` configuration file that will appear in the changelog (but won't be released), which allows for more fine-grained control over the changelog structure.

### Highlights

- Add configuration file support for additional changelog scopes
- Add ability to extract commit trailers for further validations
- Fix commit validation panicking when passing message via CLI