### PR TITLE
chore: release v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mono"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "clap",
  "cliclack",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "mono-changeset"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "globset",
  "mono-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-mono-changeset = { version = "0.0.4", path = "crates/mono-changeset" }
+mono-changeset = { version = "0.0.5", path = "crates/mono-changeset" }
 mono-project = { version = "0.0.2", path = "crates/mono-project" }
 mono-repository = { version = "0.0.3", path = "crates/mono-repository" }
 

--- a/crates/mono-changeset/Cargo.toml
+++ b/crates/mono-changeset/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-changeset"
-version = "0.0.4"
+version = "0.0.5"
 description = "Mono repository changeset utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono/Cargo.toml
+++ b/crates/mono/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono"
-version = "0.0.4"
+version = "0.0.5"
 description = "Mono repository automation toolkit"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This release changes the behavior of additional scopes that can be defined in `.mono.toml`, allowing singles files to be scopes (e.g. `Dockefile`). From now on, it's required to add a `**` path suffix to each scope that maps to a folder. Consider the following examples:

``` toml
[changeset.scopes]
python = "python/**"
docker = "Dockerfile"
```