### PR TITLE
chore: release v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mono"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "clap",
  "cliclack",

--- a/crates/mono/Cargo.toml
+++ b/crates/mono/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono"
-version = "0.0.6"
+version = "0.0.7"
 description = "Mono repository automation toolkit"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version changes the exit code to 0 in case of a merge commit.