### PR TITLE
chore: release v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mono"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "clap",
  "cliclack",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "mono-changeset"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "globset",
  "mono-project",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "mono-project"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "glob",
  "semver",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "mono-repository"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "git2",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-mono-changeset = { version = "0.0.5", path = "crates/mono-changeset" }
-mono-project = { version = "0.0.2", path = "crates/mono-project" }
-mono-repository = { version = "0.0.3", path = "crates/mono-repository" }
+mono-changeset = { version = "0.0.6", path = "crates/mono-changeset" }
+mono-project = { version = "0.0.3", path = "crates/mono-project" }
+mono-repository = { version = "0.0.4", path = "crates/mono-repository" }
 
 clap = { version = "4.6.1", features = ["derive"] }
 cliclack = "0.5.4"

--- a/crates/mono-changeset/Cargo.toml
+++ b/crates/mono-changeset/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-changeset"
-version = "0.0.5"
+version = "0.0.6"
 description = "Mono repository changeset utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono-project/Cargo.toml
+++ b/crates/mono-project/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-project"
-version = "0.0.2"
+version = "0.0.3"
 description = "Mono repository project utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono-repository/Cargo.toml
+++ b/crates/mono-repository/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-repository"
-version = "0.0.3"
+version = "0.0.4"
 description = "Mono repository git utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono/Cargo.toml
+++ b/crates/mono/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono"
-version = "0.0.7"
+version = "0.0.8"
 description = "Mono repository automation toolkit"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for multi-root workspaces, where packages are loosely coupled and can be built independently, but should be versioned together. It also introduces a new `Options` field in the `Changelog` struct, allowing to use changelogs in private repositories where GitHub references are not auto-linked.