### PR TITLE
chore: release v0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mono"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "cliclack",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "mono-changeset"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "globset",
  "mono-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-mono-changeset = { version = "0.0.7", path = "crates/mono-changeset" }
+mono-changeset = { version = "0.0.8", path = "crates/mono-changeset" }
 mono-project = { version = "0.0.3", path = "crates/mono-project" }
 mono-repository = { version = "0.0.5", path = "crates/mono-repository" }
 

--- a/crates/mono-changeset/Cargo.toml
+++ b/crates/mono-changeset/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono-changeset"
-version = "0.0.7"
+version = "0.0.8"
 description = "Mono repository changeset utilities"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mono/Cargo.toml
+++ b/crates/mono/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "mono"
-version = "0.0.10"
+version = "0.0.11"
 description = "Mono repository automation toolkit"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds backticks around the short SHA of a commit that is included with each revision in the changelog.